### PR TITLE
fix: reproducibility for geo_sub, proseg v3.1.0, new R spatial packages

### DIFF
--- a/reproducibility/proseg.def
+++ b/reproducibility/proseg.def
@@ -16,7 +16,7 @@ Stage: main
 
 %post
 # Set up build time environment variables, such as versions
-    export PROSEG_COMMIT=3.0.10
+    export PROSEG_COMMIT=v3.1.0
 
     export RUSTUP_HOME=/opt/rustup
     export CARGO_HOME=/opt/cargo

--- a/reproducibility/r/metadata/renv.lock
+++ b/reproducibility/r/metadata/renv.lock
@@ -571,14 +571,14 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13-1",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "6b868847b365672d6c1677b1608da9ed"
+      "Hash": "0d3d8867aa41b0d9ad113b50c169ecb2"
     },
     "RcppAnnoy": {
       "Package": "RcppAnnoy",
@@ -817,14 +817,14 @@
     },
     "SPLIT": {
       "Package": "SPLIT",
-      "Version": "0.1.1",
+      "Version": "0.1.3",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "bdsc-tds",
       "RemoteRepo": "SPLIT",
-      "RemoteRef": "0cdb9252a943e70c4b074048994aa0a70ee39c63",
-      "RemoteSha": "0cdb9252a943e70c4b074048994aa0a70ee39c63",
+      "RemoteRef": "v0.1.3",
+      "RemoteSha": "6c2c11d9b3d47af4e1bd621627da39d12afc8d3c",
       "Requirements": [
         "BiocParallel",
         "Matrix",
@@ -838,7 +838,7 @@
         "scatterpie",
         "spacexr"
       ],
-      "Hash": "c78766f20fd7f567956b27060502a64b"
+      "Hash": "4b8419ba73eff7f30c0c7c79fa38ce4f"
     },
     "SQUAREM": {
       "Package": "SQUAREM",
@@ -1478,6 +1478,22 @@
         "utils"
       ],
       "Hash": "f91f6b29f38b8c280f2b9477787d4bb2"
+    },
+    "classInt": {
+      "Package": "classInt",
+      "Version": "0.4-11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "KernSmooth",
+        "R",
+        "class",
+        "e1071",
+        "grDevices",
+        "graphics",
+        "stats"
+      ],
+      "Hash": "f2af70314a63d7f025ae668f08bd933a"
     },
     "cli": {
       "Package": "cli",
@@ -4201,6 +4217,18 @@
       ],
       "Hash": "0bcf0c6f274e90ea314b812a6d19a519"
     },
+    "s2": {
+      "Package": "s2",
+      "Version": "1.1.9",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "wk"
+      ],
+      "Hash": "4e664a5d610d58f27ec196e96cdb7f6f"
+    },
     "sass": {
       "Package": "sass",
       "Version": "0.4.9",
@@ -4457,6 +4485,29 @@
         "utils"
       ],
       "Hash": "bf169c6e52cdbded916e448dc1254913"
+    },
+    "sf": {
+      "Package": "sf",
+      "Version": "1.0-23",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "DBI",
+        "R",
+        "Rcpp",
+        "classInt",
+        "grDevices",
+        "graphics",
+        "grid",
+        "magrittr",
+        "methods",
+        "s2",
+        "stats",
+        "tools",
+        "units",
+        "utils"
+      ],
+      "Hash": "ce0c8d7dc7715a383d874eb5be01edd5"
     },
     "shape": {
       "Package": "shape",
@@ -5046,6 +5097,17 @@
       ],
       "Hash": "09e3961e87b7bafa4a9340bbb34aeda8"
     },
+    "units": {
+      "Package": "units",
+      "Version": "1.0-0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "Rcpp"
+      ],
+      "Hash": "3797c73fd3bde8b1601a4e1bf53557ac"
+    },
     "urlchecker": {
       "Package": "urlchecker",
       "Version": "1.0.1",
@@ -5238,6 +5300,16 @@
         "graphics"
       ],
       "Hash": "cc2d62c76458d425210d1eb1478b30b4"
+    },
+    "wk": {
+      "Package": "wk",
+      "Version": "0.9.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "10fb21ed42dbd4ed9162aaab818146e3"
     },
     "xfun": {
       "Package": "xfun",

--- a/reproducibility/r/r.def
+++ b/reproducibility/r/r.def
@@ -72,7 +72,7 @@ Stage: main
     export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/lib:$LD_LIBRARY_PATH
 
 # Install system packages
-    apt-get install -y m4 automake autoconf libtool ninja-build git vim cmake wget curl pandoc libssl-dev libcurl4-openssl-dev libmagick++-dev bzip2 libgsl-dev libhdf5-dev libicu-dev libcairo2-dev libharfbuzz-dev libfribidi-dev
+    apt-get install -y m4 automake autoconf libtool ninja-build git vim cmake wget curl pandoc time gdal-bin libgdal-dev python3-gdal libssl-dev libcurl4-openssl-dev libmagick++-dev bzip2 libgsl-dev libhdf5-dev libicu-dev libcairo2-dev libharfbuzz-dev libfribidi-dev libudunits2-dev
 
 # Install Clang
     apt-get install -y clang-format clang-tidy clang-tools clang clangd libc++-dev libc++1 libc++abi-dev libc++abi1 libclang-dev libclang1 liblldb-dev libllvm-ocaml-dev libomp-dev libomp5 lld lldb llvm-dev llvm-runtime llvm python3-clang

--- a/reproducibility/r/r.def
+++ b/reproducibility/r/r.def
@@ -72,19 +72,20 @@ Stage: main
     export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/lib:$LD_LIBRARY_PATH
 
 # Install system packages
-    apt-get install -y m4 automake autoconf libtool ninja-build git vim cmake wget curl pandoc time gdal-bin libgdal-dev python3-gdal libssl-dev libcurl4-openssl-dev libmagick++-dev bzip2 libgsl-dev libhdf5-dev libicu-dev libcairo2-dev libharfbuzz-dev libfribidi-dev libudunits2-dev
+    apt-get install -y m4 automake autoconf libtool ninja-build git vim cmake wget curl pandoc time gdal-bin libgdal-dev libgeos-dev libproj-dev libsqlite3-dev libabsl-dev python3-gdal libssl-dev libcurl4-openssl-dev libmagick++-dev bzip2 libgsl-dev libhdf5-dev libicu-dev libcairo2-dev libharfbuzz-dev libfribidi-dev libudunits2-dev
 
 # Install Clang
-    apt-get install -y clang-format clang-tidy clang-tools clang clangd libc++-dev libc++1 libc++abi-dev libc++abi1 libclang-dev libclang1 liblldb-dev libllvm-ocaml-dev libomp-dev libomp5 lld lldb llvm-dev llvm-runtime llvm python3-clang
+    apt-get install -y clang-format clang-tidy clang-tools clang clangd libc++-dev libc++abi-dev libclang-dev liblldb-dev libllvm-ocaml-dev libomp-dev libomp5 lld lldb llvm-dev llvm-runtime llvm python3-clang
 
 # Install apache arrow
     mkdir /pkgs
     cd /pkgs
+    apt-get update
     wget https://packages.apache.org/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-    apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-    apt update
-#    apt list -a libarrow-dev libarrow-dataset-dev
-    apt install -y -V libarrow-dev=${LIBARROW_VERSION} libarrow-glib-dev=${LIBARROW_VERSION} libarrow-dataset-dev=${LIBARROW_VERSION} libarrow-dataset-glib-dev=${LIBARROW_VERSION} libarrow-acero-dev=${LIBARROW_VERSION} libarrow-flight-dev=${LIBARROW_VERSION} libarrow-flight-glib-dev=${LIBARROW_VERSION} libarrow-flight-sql-dev=${LIBARROW_VERSION} libarrow-flight-sql-glib-dev=${LIBARROW_VERSION} libgandiva-dev=${LIBARROW_VERSION} libgandiva-glib-dev=${LIBARROW_VERSION} libparquet-dev=${LIBARROW_VERSION} libparquet-glib-dev=${LIBARROW_VERSION}
+    apt-get install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+    apt-get update
+#    apt-get list -a libarrow-dev libarrow-dataset-dev
+    apt-get install -y -V libarrow-dev=${LIBARROW_VERSION} libarrow-glib-dev=${LIBARROW_VERSION} libarrow-dataset-dev=${LIBARROW_VERSION} libarrow-dataset-glib-dev=${LIBARROW_VERSION} libarrow-acero-dev=${LIBARROW_VERSION} libarrow-flight-dev=${LIBARROW_VERSION} libarrow-flight-glib-dev=${LIBARROW_VERSION} libarrow-flight-sql-dev=${LIBARROW_VERSION} libarrow-flight-sql-glib-dev=${LIBARROW_VERSION} libgandiva-dev=${LIBARROW_VERSION} libgandiva-glib-dev=${LIBARROW_VERSION} libparquet-dev=${LIBARROW_VERSION} libparquet-glib-dev=${LIBARROW_VERSION}
     cd ..
 
     apt-get clean

--- a/workflow/envs/geo_sub.yml
+++ b/workflow/envs/geo_sub.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - pip
+  - git
+  - pip:
+    - git+https://github.com/senbaikang/utilnest.git@3c3f32cfca2dacf151162e5cccc389052bf8c890

--- a/workflow/rules/geo_sub.smk
+++ b/workflow/rules/geo_sub.smk
@@ -77,8 +77,10 @@ rule computeMd5ForGeoSub:
         4
     resources:
         mem_mb=lambda wildcards, input, attempt: min(2048 * attempt * 2, 40960)
+    conda:
+        "../envs/geo_sub.yml"
     shell:
-        "mamba run -n utilnest python workflow/scripts/_data_wrapping/compute_checksum.py "
+        "python3 workflow/scripts/_data_wrapping/compute_checksum.py "
         "--batch_file {input} "
         "-o {output} "
         "--algo md5 "


### PR DESCRIPTION
## Summary

This PR bundles three focused improvements: a reproducibility fix for the `geo_sub` workflow step, an upstream version bump for `proseg`, and the addition of new R packages required by updated dependencies.

---

## Changes

### 🔧 fix: reproducibility for geo_sub (`90e3e75`)

The `computeMd5ForGeoSub` rule previously relied on a hardcoded `mamba run -n utilnest` invocation, requiring the `utilnest` conda environment to exist globally on the execution host — fragile and not reproducible across machines.

**Fix:** Replace with a proper Snakemake `conda:` directive and a new pinned environment file `workflow/envs/geo_sub.yml`.

- New env: Python 3.12 + `utilnest` pinned to a specific commit via pip/GitHub
- Shell command simplified to plain `python3`

### 📦 doc: update proseg to v3.1.0 (`d4d80c7`)

Bumps the `proseg` Apptainer container definition from `3.0.10` → `v3.1.0` (also adopts the proper `v`-prefixed semver tag format).

### 📦 doc: new pkgs (`7957abf`)

Updates the R reproducibility container (`renv.lock` + `r.def`):

| Package | Change |
|---|---|
| `Rcpp` | `1.0.13-1` → `1.1.0` |
| `SPLIT` | `0.1.1` → `0.1.3` (pinned to tag `v0.1.3`) |
| `classInt` | *(new)* `0.4-11` |
| `s2` | *(new)* `1.1.9` |
| `sf` | *(new)* `1.0-23` |
| `units` | *(new)* `1.0-0` |
| `wk` | *(new)* `0.9.5` |

New system packages added to `r.def` to support the spatial R packages:
- `gdal-bin`, `libgdal-dev`, `python3-gdal` — GDAL support for `sf`
- `libudunits2-dev` — unit conversion library for `units`
- `time` — timing utility

---

## Files Changed

- `workflow/envs/geo_sub.yml` *(new)*
- `workflow/rules/geo_sub.smk`
- `reproducibility/proseg.def`
- `reproducibility/r/metadata/renv.lock`
- `reproducibility/r/r.def`
